### PR TITLE
cicd updates to github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,10 @@ updates:
     open-pull-requests-limit: 100
     reviewers:
       - cmgrote
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "03:00"
+      timezone: "Etc/UTC"
 ...

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,16 +33,16 @@ jobs:
 
     steps:
       - name: Setup Java JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
       #    make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/maven-java11-verify.yml
+++ b/.github/workflows/maven-java11-verify.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     name: "Maven Java 11"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Cache Maven packages
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-maven-java11-${{ hashFiles('**/pom.xml') }}
@@ -27,7 +27,7 @@ jobs:
       - name: Build with Maven
         run: mvn -DargLine="-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:GCTimeRatio=99" -B clean verify --file pom.xml
       - name: Upload assemblies
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Assemblies
           path: |

--- a/.github/workflows/maven-java17-verify.yml
+++ b/.github/workflows/maven-java17-verify.yml
@@ -11,23 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     name: "Maven Java 16"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout
-      - name: Set up JDK 16
-        uses: actions/setup-java@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
-          java-version: '16'
+          distribution: 'temurin'
+          java-version: '17'
       - name: Cache Maven packages
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v3
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-maven-java16-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-java16
+          key: ${{ runner.os }}-maven-java17-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-java17
       - name: Build with Maven
         run: mvn -DargLine="-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:GCTimeRatio=99" -B clean verify --file pom.xml
       - name: Upload assemblies
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Assemblies
           path: |

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     name: "Merge"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout source
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           # Java 11 is used for merge builds (PRs do check Java latest)
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           # Publishing attributes for maven central (this step adds to setting.xml)
           server-id: ossrh
           server-username: MAVEN_USERNAME
@@ -46,7 +46,7 @@ jobs:
         run: mvn -B clean verify
       # Mostly for verification - not published to the release itself for now
       - name: Upload assemblies
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Assemblies
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     name: "Release"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout source
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           # Java 11 is used for final released build
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           # Publishing attributes for maven central (this step adds to setting.xml)
           server-id: ossrh
           server-username: MAVEN_USERNAME
@@ -38,7 +38,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
       # Mostly for verification - not published to the release itself for now
       - name: Upload assemblies
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Assemblies
           path: |


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

When checking post-branch renames I make the following suggestions
* Use temurin not adopt in build scripts
* change the 'later' version java build from 16 to 17
* Update actions
* Add actions version check to dependabot

fyi @cmgrote 