### PR TITLE
Gradle refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,7 @@ subprojects {
 
     dependencies {
         // This adds constraints (which can be overriden below) for all dependencies egeria uses
-        //TODO - needs reinstating. Currently not working due to https://github.com/odpi/egeria/issues/7421
-        //implementation platform("org.odpi.egeria:egeria:${egeriaVersion}")
+        implementation platform("org.odpi.egeria:egeria:${egeriaVersion}")
 
         // specifies versions if dependencies used in projects
         constraints

--- a/build.gradle
+++ b/build.gradle
@@ -8,14 +8,15 @@
  * Plugins for this parent module only - so just high level project related
  */
 plugins {
-    id "io.freefair.aggregate-javadoc" version "6.6.1"
-    id "io.freefair.lombok" version "6.6.1"
+    id "com.github.johnrengelman.shadow" version "7.1.2"
+    id 'idea'
+    id 'maven-publish'
     // Checks for unnecessary dependencies
-    id 'com.autonomousapps.dependency-analysis' version "1.18.0"
+    id 'com.autonomousapps.dependency-analysis' version "1.19.0"
     // helps resolve log implementation clashes
     id 'dev.jacomet.logging-capabilities' version "0.10.0"
     // This plugin helps resolve jakarta/javax dev.jacomet.logging-capabilities
-    id 'org.gradlex.java-ecosystem-capabilities' version "1.0"
+    id 'org.gradlex.java-ecosystem-capabilities' version "1.1"
 }
 
 
@@ -23,21 +24,24 @@ plugins {
  * Configuration for all projects - INCLUDING this one
  */
 
-allprojects {
+subprojects {
 
     group = 'org.odpi.egeria'
     version = '4.0-SNAPSHOT'
 
     // Mostly java, so default to this for now
     apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'jacoco'
     apply plugin: 'org.gradlex.java-ecosystem-capabilities'
     apply plugin: 'dev.jacomet.logging-capabilities'
-    // As we've migrated from maven - we'll assume all submodules publish directly to maven
     apply plugin: 'maven-publish'
+    apply plugin: 'com.autonomousapps.dependency-analysis'
+    apply plugin: 'com.github.johnrengelman.shadow'
 
     repositories {
         mavenCentral()
+        google()
         maven {
             url "https://oss.sonatype.org/content/repositories/snapshots/"
             mavenContent {
@@ -76,58 +80,56 @@ allprojects {
     }
 
     dependencies {
-        implementation("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
-        implementation("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
-        implementation("com.xtdb:xtdb-core:${xtdbVersion}")
-        implementation("org.clojure:clojure:${clojureVersion}")
-        implementation("org.apache.lucene:lucene-core:${luceneVersion}")
-        implementation("org.apache.lucene:lucene-queryparser:${luceneVersion}")
-        // Dependencies only required if configured to run with these extras: they will be included in the
-        // 'jar-with-dependencies' by default, but if you do not need them you can remove them and re-build
-        // to get a smaller footprint with less potential CVE exposure.
-        runtimeOnly("org.apache.lucene:lucene-analyzers-common:${luceneVersion}")
-        runtimeOnly("com.xtdb:xtdb-lucene:${xtdbVersion}")
-        runtimeOnly("com.xtdb:xtdb-rocksdb:${xtdbVersion}")
-        runtimeOnly("com.xtdb:xtdb-lmdb:${xtdbVersion}")
-        runtimeOnly("com.xtdb:xtdb-kafka:${xtdbVersion}")
-        // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-38153
-        runtimeOnly("org.apache.kafka:kafka-clients:${kafkaVersion}")
-        // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2020-28491
-        runtimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}")
-        runtimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${jacksonVersion}")
-        runtimeOnly("com.xtdb:xtdb-jdbc:${xtdbVersion}")
-        runtimeOnly("com.xtdb:xtdb-s3:${xtdbVersion}")
-        // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2020-13956
-        runtimeOnly("org.apache.httpcomponents:httpclient:${httpclientVersion}")
-        // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-21295
-        runtimeOnly("io.netty:netty-codec-http2:${nettyVersion}")
-        // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-43797
-        runtimeOnly("io.netty:netty-codec-http:${nettyVersion}")
-        // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-37136, CVE-2021-37137
-        runtimeOnly("io.netty:netty-codec:${nettyVersion}")
-        // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2020-0026
-        runtimeOnly("io.netty:netty-handler:${nettyVersion}")
-        // Following dependency is to ensure we use updated version of dependent library to avoid sonatype-2012-0050
-        runtimeOnly("commons-codec:commons-codec:${commonscodecVersion}")
-        runtimeOnly("com.xtdb:xtdb-metrics:${xtdbVersion}")
-        // Dependencies provided by Egeria itself
-        implementation("org.odpi.egeria:audit-log-framework:${egeriaVersion}")
-        implementation("org.odpi.egeria:repository-services-apis:${egeriaVersion}")
-        implementation("org.odpi.egeria:open-connector-framework:${egeriaVersion}")
-        implementation("org.slf4j:slf4j-api:${slf4jVersion}")
-        // Dependencies only used for the build-time tests
-        implementation("ch.qos.logback:logback-classic:${logbackVersion}")
-        testImplementation("org.testng:testng:${testngVersion}") {
-            // Exclude snakeyaml, which has open CVEs and is unused
-            exclude group: "org.yaml", module: "snakeyaml"
-            exclude group: "org.apache.ant", module: "ant"
-        }
-        testImplementation("org.odpi.egeria:repository-services-implementation:${egeriaVersion}")
-        testImplementation("org.odpi.egeria:connector-configuration-factory:${egeriaVersion}") {
-            // Exclude the graph repository, as unused and will extend to many other dependencies
-            exclude group: "org.odpi.egeria", module: "graph-repository-connector"
-        }
-        testImplementation("org.odpi.egeria:open-metadata-types:${egeriaVersion}")
+        // This adds constraints (which can be overriden below) for all dependencies egeria uses
+        //TODO - needs reinstating. Currently not working due to https://github.com/odpi/egeria/issues/7421
+        //implementation platform("org.odpi.egeria:egeria:${egeriaVersion}")
+
+        // specifies versions if dependencies used in projects
+        constraints
+                {
+                    implementation("ch.qos.logback:logback-classic:${logbackVersion}")
+                    implementation("org.odpi.egeria:audit-log-framework:${egeriaVersion}")
+                    implementation("org.odpi.egeria:repository-services-apis:${egeriaVersion}")
+                    implementation("org.odpi.egeria:open-connector-framework:${egeriaVersion}")
+
+                    compileOnly("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
+                    compileOnly("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
+                    implementation("com.xtdb:xtdb-core:${xtdbVersion}")
+                    implementation("org.clojure:clojure:${clojureVersion}")
+                    implementation("org.apache.lucene:lucene-core:${luceneVersion}")
+                    implementation("org.apache.lucene:lucene-queryparser:${luceneVersion}")
+                    // Dependencies only required if configured to run with these extras: they will be included in the
+                    // 'jar-with-dependencies' by default, but if you do not need them you can remove them and re-build
+                    // to get a smaller footprint with less potential CVE exposure.
+                    runtimeOnly("org.apache.lucene:lucene-analyzers-common:${luceneVersion}")
+                    runtimeOnly("com.xtdb:xtdb-lucene:${xtdbVersion}")
+                    runtimeOnly("com.xtdb:xtdb-rocksdb:${xtdbVersion}")
+                    runtimeOnly("com.xtdb:xtdb-lmdb:${xtdbVersion}")
+                    runtimeOnly("com.xtdb:xtdb-kafka:${xtdbVersion}")
+                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-38153
+                    compileOnly("org.apache.kafka:kafka-clients:${kafkaVersion}")
+                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2020-28491
+                    runtimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}")
+                    runtimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${jacksonVersion}")
+                    testCompileOnly("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
+
+                    runtimeOnly("com.xtdb:xtdb-jdbc:${xtdbVersion}")
+                    runtimeOnly("com.xtdb:xtdb-s3:${xtdbVersion}")
+
+                    runtimeOnly("com.xtdb:xtdb-metrics:${xtdbVersion}")
+                    // Dependencies provided by Egeria itself
+                    compileOnly("org.odpi.egeria:audit-log-framework:${egeriaVersion}")
+                    compileOnly("org.odpi.egeria:repository-services-apis:${egeriaVersion}")
+                    compileOnly("org.odpi.egeria:open-connector-framework:${egeriaVersion}")
+                    compileOnly("org.slf4j:slf4j-api:${slf4jVersion}")
+
+                    // Dependencies only used for the build-time tests
+                    testImplementation("ch.qos.logback:logback-classic:${logbackVersion}")
+                    testImplementation("org.testng:testng:${testngVersion}")
+                    testImplementation("org.odpi.egeria:repository-services-implementation:${egeriaVersion}")
+                    testImplementation("org.odpi.egeria:connector-configuration-factory:${egeriaVersion}")
+                    testImplementation("org.odpi.egeria:open-metadata-types:${egeriaVersion}")
+                }
     }
 
     /*
@@ -155,9 +157,9 @@ allprojects {
         toolVersion = "0.8.8"
     }
 
-    // lombok
-    lombok {
-        version = "${lombokVersion}"
+    // Uber jar
+    shadowJar {
+        archiveClassifier = 'jar-with-dependencies'
     }
     // Testing
     test {
@@ -221,35 +223,28 @@ allprojects {
         // Secrets for credentials
         repositories {
             maven {
-                    name = 'OSSRH'
-                    def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-                    def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
-                    url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-                    // User token (under profile) on oss.sonatype.org
-                    credentials {
-                        username = System.getenv("OSSRH_USERNAME")
-                        password = System.getenv("OSSRH_TOKEN")
-                    }
+                name = 'OSSRH'
+                def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+                def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                // User token (under profile) on oss.sonatype.org
+                credentials {
+                    username = System.getenv("OSSRH_USERNAME")
+                    password = System.getenv("OSSRH_TOKEN")
                 }
+            }
         }
     }
 
-    /*
-     * Additional useful tasks
-     */
-    task printAllDependencies(type: DependencyReportTask) {}
-    task printSubDependencies(type: DependencyReportTask) {}
-    task findDependency(type: DependencyInsightReportTask) {}
 
-} // end of allProjects
+} // end of subProjects
 
 
-/*
- * Configuration for sub projects only
- */
-subprojects {
-    // All tasks currently will run under allProjects - which includes root.
-}
+apply plugin: 'java' // this is enough to ensure the build can be launched from the root project
+// Additional useful tasks
+task printAllDependencies(type: DependencyReportTask) {}
+task printSubDependencies(type: DependencyReportTask) {}
+task findDependency(type: DependencyInsightReportTask) {}
 
 
 /*
@@ -291,9 +286,9 @@ dependencyAnalysis {
             onAny {
                 severity('fail')
             }
-            onUnusedDependencies {
-                exclude("com.fasterxml.jackson.core:jackson-annotations")
-            }
+            //onUnusedDependencies {
+            //    exclude("com.fasterxml.jackson.core:jackson-annotations")
+            //}
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,19 @@ subprojects {
                     runtimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${jacksonVersion}")
                     testCompileOnly("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
 
+                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2020-13956
+                    runtimeOnly("org.apache.httpcomponents:httpclient:${httpclientVersion}")
+                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-21295
+                    runtimeOnly("io.netty:netty-codec-http2:${nettyVersion}")
+                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-43797
+                    runtimeOnly("io.netty:netty-codec-http:${nettyVersion}")
+                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-37136, CVE-2021-37137
+                    runtimeOnly("io.netty:netty-codec:${nettyVersion}")
+                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2020-0026
+                    runtimeOnly("io.netty:netty-handler:${nettyVersion}")
+                    // Following dependency is to ensure we use updated version of dependent library to avoid sonatype-2012-0050
+                    runtimeOnly("commons-codec:commons-codec:${commonscodecVersion}")
+
                     runtimeOnly("com.xtdb:xtdb-jdbc:${xtdbVersion}")
                     runtimeOnly("com.xtdb:xtdb-s3:${xtdbVersion}")
 

--- a/connector/build.gradle
+++ b/connector/build.gradle
@@ -3,21 +3,60 @@
  * Copyright Contributors to the ODPi Egeria project.
  */
 
+
 dependencies {
-    testImplementation "ch.qos.logback:logback-classic"
+    // Compile only - already included in egeria
+    compileOnly("com.fasterxml.jackson.core:jackson-databind")
+    compileOnly("com.fasterxml.jackson.core:jackson-annotations")
+
+    // Dependencies provided by Egeria itself
+    compileOnly("org.odpi.egeria:audit-log-framework")
+    compileOnly("org.odpi.egeria:repository-services-apis")
+    compileOnly("org.odpi.egeria:open-connector-framework")
+    compileOnly("org.slf4j:slf4j-api")
+    compileOnly("org.apache.kafka:kafka-clients")
+
+    // Compile and run
+    implementation("org.apache.lucene:lucene-queryparser")
+    api("com.xtdb:xtdb-core")
+    api("org.clojure:clojure")
+
+    // Dependencies only required if configured to run with these extras: they will be included in the
+    // 'jar-with-dependencies' by default, but if you do not need them you can remove them and re-build
+    // to get a smaller footprint with less potential CVE exposure.
+    // These are only used by the connector at runtime
+    runtimeOnly("org.apache.lucene:lucene-core")
+    runtimeOnly("org.apache.lucene:lucene-analyzers-common")
+    runtimeOnly("com.xtdb:xtdb-lucene")
+    runtimeOnly("com.xtdb:xtdb-rocksdb")
+    runtimeOnly("com.xtdb:xtdb-lmdb")
+    runtimeOnly("com.xtdb:xtdb-kafka")
+    runtimeOnly("com.xtdb:xtdb-jdbc")
+    runtimeOnly("com.xtdb:xtdb-s3")
+    runtimeOnly("com.xtdb:xtdb-metrics")
+
+    runtimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
+    runtimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
+
+    // Dependencies only used for the build-time tests
+    testRuntimeOnly("ch.qos.logback:logback-classic")
+    testImplementation("org.testng:testng") {
+        // Exclude snakeyaml, which has open CVEs and is unused
+        exclude group: "org.yaml", module: "snakeyaml"
+        exclude group: "org.apache.ant", module: "ant"
+    }
+    // We need these egeria libraries for testing
+    testImplementation("org.odpi.egeria:repository-services-implementation")
+    testImplementation("org.odpi.egeria:connector-configuration-factory") {
+        // Exclude the graph repository, as unused and will extend to many other dependencies
+        exclude group: "org.odpi.egeria", module: "graph-repository-connector"
+    }
+    testImplementation("org.odpi.egeria:open-metadata-types")
+    testCompileOnly("org.odpi.egeria:audit-log-framework")
+    testCompileOnly("org.odpi.egeria:repository-services-apis")
+    testCompileOnly("org.odpi.egeria:open-connector-framework")
 }
 
 description = 'An OCF OMRS Connector for a historical metadata back-end based on XTDB.'
 
-java {
-    withJavadocJar()
-}
-
-task withDependencies(type: Jar) {
-    archiveClassifier = 'jar-with-dependencies'
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
-    with jar
-}
-
-build.dependsOn("withDependencies")
+build.dependsOn shadowJar

--- a/migrator/build.gradle
+++ b/migrator/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation("org.clojure:clojure")
     compileOnly("org.slf4j:slf4j-api")
     testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
+    testRuntimeOnly("org.odpi.egeria:repository-services-apis")
     testImplementation("org.testng:testng") {
         // Exclude snakeyaml, which has open CVEs and is unused
         exclude group: "org.yaml", module: "snakeyaml"

--- a/migrator/build.gradle
+++ b/migrator/build.gradle
@@ -5,27 +5,18 @@
 
 dependencies {
     implementation project(":egeria-connector-xtdb")
-    implementation "ch.qos.logback:logback-classic"
-    runtimeOnly "org.odpi.egeria:audit-log-framework"
-    runtimeOnly "org.odpi.egeria:repository-services-apis"
-    runtimeOnly "org.odpi.egeria:open-connector-framework"
-    compileOnly "org.slf4j:slf4j-api"
+    api("com.xtdb:xtdb-core")
+    implementation("org.clojure:clojure")
+    compileOnly("org.slf4j:slf4j-api")
+    testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
+    testImplementation("org.testng:testng") {
+        // Exclude snakeyaml, which has open CVEs and is unused
+        exclude group: "org.yaml", module: "snakeyaml"
+        exclude group: "org.apache.ant", module: "ant"
+    }
+
 }
 
 description = 'Migration utilities for the OCF OMRS Connector for a historical metadata back-end based on XTDB.'
 
-java {
-    withJavadocJar()
-}
-
-task withDependencies(type: Jar) {
-    manifest {
-        attributes 'Main-Class': 'org.odpi.egeria.connectors.juxt.xtdb.migration.Migrator'
-    }
-    archiveClassifier = 'jar-with-dependencies'
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
-    with jar
-}
-
-build.dependsOn("withDependencies")
+build.dependsOn shadowJar


### PR DESCRIPTION
Initial PR for refactoring of gradle dependencies
- Uses shadow plugin for building uber jars
- Moves version specs to dependency constraints
- updates plugin versions
- Ensures project/build health run for both projects
- removes most tasks from top level project - no need to publish it
- cleans up dependencies as reported by dependency analysis plugin

Caveats
 - Ideally we'd depend on the egeria BOM, but this is currently broken for v4
 
 Todo
  - identify runtime dependencies for migrator (any additional to core connector?)
  - test connector & migrator 
  