### PR TITLE
Update Egeria to 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This repository houses the code for a plugin repository connector using [XTDB](h
 
 Of particular interest for Egeria is that it has native support for storing historical information and temporal queries -- making it one of the first repositories to support the use of the `asOfTime` parameter across all metadata.
 
-## [Documentation](https://odpi.github.io/egeria-docs/connectors/repository/xtdb/)
+## [Documentation](https://egeria-project.org/connectors/repository/xtdb/)
 
-[https://odpi.github.io/egeria-docs/connectors/repository/xtdb/](https://odpi.github.io/egeria-docs/connectors/repository/xtdb/)
+[https://egeria-project.org/connectors/repository/xtdb/](https://egeria-project.org/connectors/repository/xtdb/)
 
 ----
 License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
     // Assign variables for any constraints
     ext {
         lombokVersion = '1.18.24'
-        egeriaVersion = '4.0-SNAPSHOT'
+        egeriaVersion = '4.0'
         xtdbVersion = '1.23.0'
         clojureVersion = '1.11.1'
         jacksonVersion = '2.14.1'
@@ -82,17 +82,13 @@ subprojects {
     }
 
     dependencies {
-        // This adds constraints (which can be overriden below) for all dependencies egeria uses
+        // This adds constraints (which can be overridden below) for all dependencies egeria uses
         implementation platform("org.odpi.egeria:egeria:${egeriaVersion}")
 
         // specifies versions if dependencies used in projects
         constraints
                 {
                     implementation("ch.qos.logback:logback-classic:${logbackVersion}")
-                    implementation("org.odpi.egeria:audit-log-framework:${egeriaVersion}")
-                    implementation("org.odpi.egeria:repository-services-apis:${egeriaVersion}")
-                    implementation("org.odpi.egeria:open-connector-framework:${egeriaVersion}")
-
                     compileOnly("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
                     compileOnly("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
                     implementation("com.xtdb:xtdb-core:${xtdbVersion}")

--- a/build.gradle
+++ b/build.gradle
@@ -64,21 +64,9 @@ subprojects {
 
     // Assign variables for any constraints
     ext {
-        lombokVersion = '1.18.24'
         egeriaVersion = '4.0'
         xtdbVersion = '1.23.0'
         clojureVersion = '1.11.1'
-        jacksonVersion = '2.14.1'
-        luceneVersion = '8.9.0'
-        slf4jVersion = '2.0.6'
-        logbackVersion = '1.4.5'
-        testngVersion = '7.6.1'
-        // Dependent libraries
-        httpclientVersion = '4.5.14'
-        nettyVersion = '4.1.79.Final'
-        kafkaVersion = '3.4.0'
-        jacksonDataFormatVersion = '2.14.1'
-        commonscodecVersion = '1.15'
     }
 
     dependencies {
@@ -88,58 +76,22 @@ subprojects {
         // specifies versions if dependencies used in projects
         constraints
                 {
-                    implementation("ch.qos.logback:logback-classic:${logbackVersion}")
-                    compileOnly("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
-                    compileOnly("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
-                    implementation("com.xtdb:xtdb-core:${xtdbVersion}")
+                   implementation("com.xtdb:xtdb-core:${xtdbVersion}")
                     implementation("org.clojure:clojure:${clojureVersion}")
-                    implementation("org.apache.lucene:lucene-core:${luceneVersion}")
-                    implementation("org.apache.lucene:lucene-queryparser:${luceneVersion}")
                     // Dependencies only required if configured to run with these extras: they will be included in the
                     // 'jar-with-dependencies' by default, but if you do not need them you can remove them and re-build
                     // to get a smaller footprint with less potential CVE exposure.
-                    runtimeOnly("org.apache.lucene:lucene-analyzers-common:${luceneVersion}")
+                    // runtimeOnly("org.apache.lucene:lucene-analyzers-common:${luceneVersion}")
                     runtimeOnly("com.xtdb:xtdb-lucene:${xtdbVersion}")
                     runtimeOnly("com.xtdb:xtdb-rocksdb:${xtdbVersion}")
                     runtimeOnly("com.xtdb:xtdb-lmdb:${xtdbVersion}")
                     runtimeOnly("com.xtdb:xtdb-kafka:${xtdbVersion}")
-                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-38153
-                    compileOnly("org.apache.kafka:kafka-clients:${kafkaVersion}")
-                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2020-28491
-                    runtimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jacksonVersion}")
-                    runtimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${jacksonVersion}")
-                    testCompileOnly("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
-
-                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2020-13956
-                    runtimeOnly("org.apache.httpcomponents:httpclient:${httpclientVersion}")
-                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-21295
-                    runtimeOnly("io.netty:netty-codec-http2:${nettyVersion}")
-                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-43797
-                    runtimeOnly("io.netty:netty-codec-http:${nettyVersion}")
-                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2021-37136, CVE-2021-37137
-                    runtimeOnly("io.netty:netty-codec:${nettyVersion}")
-                    // Following dependency is to ensure we use updated version of dependent library to avoid CVE-2020-0026
-                    runtimeOnly("io.netty:netty-handler:${nettyVersion}")
-                    // Following dependency is to ensure we use updated version of dependent library to avoid sonatype-2012-0050
-                    runtimeOnly("commons-codec:commons-codec:${commonscodecVersion}")
 
                     runtimeOnly("com.xtdb:xtdb-jdbc:${xtdbVersion}")
                     runtimeOnly("com.xtdb:xtdb-s3:${xtdbVersion}")
 
                     runtimeOnly("com.xtdb:xtdb-metrics:${xtdbVersion}")
-                    // Dependencies provided by Egeria itself
-                    compileOnly("org.odpi.egeria:audit-log-framework:${egeriaVersion}")
-                    compileOnly("org.odpi.egeria:repository-services-apis:${egeriaVersion}")
-                    compileOnly("org.odpi.egeria:open-connector-framework:${egeriaVersion}")
-                    compileOnly("org.slf4j:slf4j-api:${slf4jVersion}")
-
-                    // Dependencies only used for the build-time tests
-                    testImplementation("ch.qos.logback:logback-classic:${logbackVersion}")
-                    testImplementation("org.testng:testng:${testngVersion}")
-                    testImplementation("org.odpi.egeria:repository-services-implementation:${egeriaVersion}")
-                    testImplementation("org.odpi.egeria:connector-configuration-factory:${egeriaVersion}")
-                    testImplementation("org.odpi.egeria:open-metadata-types:${egeriaVersion}")
-                }
+                 }
     }
 
     /*
@@ -159,7 +111,7 @@ subprojects {
 
     // javadoc
     javadoc {
-        options.addBooleanOption('html5', true)
+        options.addBooleanOption('html5', true) // default
     }
 
     // code coverage

--- a/connector/build.gradle
+++ b/connector/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     testCompileOnly("org.odpi.egeria:audit-log-framework")
     testCompileOnly("org.odpi.egeria:repository-services-apis")
     testCompileOnly("org.odpi.egeria:open-connector-framework")
+    testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
 }
 
 description = 'An OCF OMRS Connector for a historical metadata back-end based on XTDB.'

--- a/connector/src/main/java/org/odpi/egeria/connectors/juxt/xtdb/repositoryconnector/XtdbOMRSRepositoryConnectorProvider.java
+++ b/connector/src/main/java/org/odpi/egeria/connectors/juxt/xtdb/repositoryconnector/XtdbOMRSRepositoryConnectorProvider.java
@@ -91,7 +91,7 @@ public class XtdbOMRSRepositoryConnectorProvider extends OMRSRepositoryConnector
     private static final String connectorQualifiedName = "Egeria:OMRSRepositoryConnector:XTDB";
     private static final String connectorDisplayName = "XTDB-based OMRS Repository Connector";
     private static final String connectorDescription = "Plugin open metadata repository connector that maps open metadata calls to an XTDB-based metadata repository.";
-    private static final String connectorWikiPage = "https://odpi.github.io/egeria-docs/connectors/repository/xtdb/";
+    private static final String connectorWikiPage = "https://egeria-project.org/egeria-docs/connectors/repository/xtdb/";
 
     /*
      * Class of the connector.


### PR DESCRIPTION
This PR moves the build level of Egeria from 4.0-SNAPSHOT to 4.0.  It also removes some unnecessary dependencies from `build.gradle` and updates links to the documentation to use the official URL.